### PR TITLE
Making exterior doors appear in the description of a RoomWithDoor

### DIFF
--- a/VS2013/Chapter_7/HideAndSeek/HideAndSeek/RoomWithDoor.cs
+++ b/VS2013/Chapter_7/HideAndSeek/HideAndSeek/RoomWithDoor.cs
@@ -18,5 +18,10 @@ namespace HideAndSeek
         public string DoorDescription { get; private set; }
 
         public Location DoorLocation { get; set; }
+
+        public override string Description
+        {
+            get { return base.Description + " You see " + DoorDescription + "."; }
+        }
     }
 }

--- a/VS2013/Chapter_7/LetsBuildAHouse/LetsBuildAHouse/RoomWithDoor.cs
+++ b/VS2013/Chapter_7/LetsBuildAHouse/LetsBuildAHouse/RoomWithDoor.cs
@@ -17,5 +17,10 @@ namespace LetsBuildAHouse
         public string DoorDescription { get; private set; }
 
         public Location DoorLocation { get; set; }
+
+        public override string Description
+        {
+            get { return base.Description + " You see " + DoorDescription + "."; }
+        }
     }
 }


### PR DESCRIPTION
Previously, the exterior doors didn't appear in the description when we were inside a room with an exterior door.